### PR TITLE
fixed encoding

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -6,7 +6,7 @@
 
 	<target name="build">
 		<mkdir dir="ant-bin" />
-		<javac srcdir="src/main/java:src/test/java" destdir="ant-bin" includeantruntime="false" classpath="${cp.lib}" />
+		<javac srcdir="src/main/java:src/test/java" destdir="ant-bin" includeantruntime="false" classpath="${cp.lib}" encoding="UTF-8"/>
 	</target>
 
 	<target name="test" depends="build">


### PR DESCRIPTION
Didn't build on my system since you were using åäö.
Fixed this by specifying character encoding.